### PR TITLE
Switch PI to M_PI to support STRICT_R_HEADERS

### DIFF
--- a/src/gfilmm.cpp
+++ b/src/gfilmm.cpp
@@ -190,7 +190,7 @@ const std::vector<Real> fidSample(
               std::min(MIN, std::min((U - VTsum.coeff(zni)) / VT2.coeff(zni),
                                      (L - VTsum.coeff(zni)) / VT2.coeff(zni)));
         }
-        temp = 1 - (atan(MIN) / PI + 0.5);
+        temp = 1 - (atan(MIN) / M_PI + 0.5);
       } else if((d2 && c1) || (d1 && c2)) {
         MIN = -infty;
         MAX = -infty;
@@ -200,7 +200,7 @@ const std::vector<Real> fidSample(
               std::max(MAX, std::max((U - VTsum.coeff(zni)) / VT2.coeff(zni),
                                      (L - VTsum.coeff(zni)) / VT2.coeff(zni)));
         }
-        temp = atan(MAX) / PI + 0.5;
+        temp = atan(MAX) / M_PI + 0.5;
       } else {
         Real Hmax = -infty;
         Real Hmin = infty;
@@ -239,14 +239,14 @@ const std::vector<Real> fidSample(
         }
         Real Pprob, Nprob;
         if(tpos == infty) {
-          Pprob = 1 - (atan(bpos) / PI + 0.5);
+          Pprob = 1 - (atan(bpos) / M_PI + 0.5);
         } else {
-          Pprob = atan(tpos) / PI + 0.5;
+          Pprob = atan(tpos) / M_PI + 0.5;
         }
         if(tneg == infty) {
-          Nprob = 1 - (atan(bneg) / PI + 0.5);
+          Nprob = 1 - (atan(bneg) / M_PI + 0.5);
         } else {
-          Nprob = atan(tneg) / PI + 0.5;
+          Nprob = atan(tneg) / M_PI + 0.5;
         }
         temp = Pprob + Nprob;
         Pprob = Pprob / temp;
@@ -260,10 +260,10 @@ const std::vector<Real> fidSample(
         }
       }
     }
-    const Real y = atan(MAX) / PI + 0.5;
-    const Real x = atan(MIN) / PI + 0.5;
+    const Real y = atan(MAX) / M_PI + 0.5;
+    const Real x = atan(MIN) / M_PI + 0.5;
     const Real u = x + (y - x) * runif(generator);
-    ZZ = tan(PI * (u - 0.5));
+    ZZ = tan(M_PI * (u - 0.5));
     const Real ZZ2 = ZZ * ZZ;
     wt = exp(-ZZ2 / 2) * (1 + ZZ2) * temp;
   } else {
@@ -275,10 +275,10 @@ const std::vector<Real> fidSample(
       MAX = std::max(MAX, std::max(xu, xl));
       MIN = std::min(MIN, std::min(xu, xl));
     }
-    const Real y = atan(MAX) / PI + 0.5;
-    const Real x = atan(MIN) / PI + 0.5;
+    const Real y = atan(MAX) / M_PI + 0.5;
+    const Real x = atan(MIN) / M_PI + 0.5;
     const Real u = x + (y - x) * runif(generator);
-    ZZ = tan(PI * (u - 0.5));
+    ZZ = tan(M_PI * (u - 0.5));
     const Real ZZ2 = ZZ * ZZ;
     wt = exp(-ZZ2 / 2) * (1 + ZZ2) * (y - x);
   }


### PR DESCRIPTION
Dear Stéphane,

The Rcpp team is trying to move towards defining STRICT_R_HEADERS by default. Please the issue ticket at https://github.com/RcppCore/Rcpp/issues/1158 for motivation and history.

Your package uses (in one file) PI (instead of the standard C define M_PI, or e.g. the newer Armadillo constant arma::datum::pi) and PI goes away when we set STRICT_R_HEADERS (as a #define in a header or source file, a -DSTRICT_R_HEADERS as a compiler flag, or as a #define in the Rcpp sources as we currently do). We plan to enable STRICT_R_HEADERS by the Jan 2022 release of Rcpp, and will likely offer you a define to suppress it. So if you really do not want the change you can prevent it -- see these lines in Rcpp for details:
https://github.com/RcppCore/Rcpp/blob/e79c70e76bc2a776d2d57287f7192dbdbcb292aa/inst/include/Rcpp/r/headers.h#L28-L38

This very simple PR changes PI to M_PI. Your code will then work with and without STRICT_R_HEADERS (as M_PI is an old define from C). PI only works when STRICT_R_HEADERS is not defined.

As discussed in https://github.com/RcppCore/Rcpp/issues/1158, this is not urgent, but we of course welcome relatively prompt resolution at CRAN so when we continue to test for this (at a likely montly pace) so we do not get false positives as we will continue to use the CRAN set of packages (as opposed to hand-curated set of upstream dev versions).

Many thanks for your help, and I hope you continue to find Rcpp helpful. Please don't hesitate to ask if you have any questions.